### PR TITLE
Respect PI_CODING_AGENT_DIR for all path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Place this folder in one of the following locations:
 
 Pi auto-discovers extensions in these paths.
 
+> **Tip:** All `~/.pi/agent` paths shown in this document are defaults. If the `PI_CODING_AGENT_DIR` environment variable is set, pi uses that directory instead. The extension automatically follows pi's `getAgentDir()` helper, so global policy files, per-agent overrides, session directories, and extension installation paths all resolve under the configured agent directory.
+
 ## Usage
 
 ### Quick Start

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { isToolCallEventType, type ExtensionAPI, type ExtensionCommandContext, type ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, isToolCallEventType, type ExtensionAPI, type ExtensionCommandContext, type ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, normalize, resolve, sep } from "node:path";
@@ -32,7 +32,7 @@ import type { PermissionCheckResult, PermissionState } from "./types.js";
 import { PERMISSION_SYSTEM_STATUS_KEY, syncPermissionSystemStatus } from "./status.js";
 import { canResolveAskPermissionRequest, shouldAutoApprovePermissionState } from "./yolo-mode.js";
 
-const PI_AGENT_DIR = join(homedir(), ".pi", "agent");
+const PI_AGENT_DIR = getAgentDir();
 const SESSIONS_DIR = join(PI_AGENT_DIR, "sessions");
 const SUBAGENT_SESSIONS_DIR = join(PI_AGENT_DIR, "subagent-sessions");
 const PERMISSION_FORWARDING_DIR = join(SESSIONS_DIR, "permission-forwarding");

--- a/src/permission-manager.ts
+++ b/src/permission-manager.ts
@@ -1,6 +1,7 @@
 import { readFileSync, statSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
 
 import { BashFilter } from "./bash-filter.js";
 import { extractFrontmatter, getNonEmptyString, isPermissionState, parseSimpleYamlMap, toRecord } from "./common.js";
@@ -19,10 +20,10 @@ import {
   type CompiledWildcardPattern,
 } from "./wildcard-matcher.js";
 
-const GLOBAL_CONFIG_PATH = join(homedir(), ".pi", "agent", "pi-permissions.jsonc");
-const AGENTS_DIR = join(homedir(), ".pi", "agent", "agents");
-const LEGACY_GLOBAL_SETTINGS_PATH = join(homedir(), ".pi", "agent", "settings.json");
-const GLOBAL_MCP_CONFIG_PATH = join(homedir(), ".pi", "agent", "mcp.json");
+function defaultGlobalConfigPath(): string { return join(getAgentDir(), "pi-permissions.jsonc"); }
+function defaultAgentsDir(): string { return join(getAgentDir(), "agents"); }
+function defaultLegacyGlobalSettingsPath(): string { return join(getAgentDir(), "settings.json"); }
+function defaultGlobalMcpConfigPath(): string { return join(getAgentDir(), "mcp.json"); }
 
 const BUILT_IN_TOOL_PERMISSION_NAMES = new Set(["bash", "read", "write", "edit", "grep", "find", "ls"]);
 const SPECIAL_PERMISSION_KEYS = new Set(["doom_loop", "external_directory"]);
@@ -441,10 +442,10 @@ export class PermissionManager {
       mcpServerNames?: readonly string[];
     } = {},
   ) {
-    this.globalConfigPath = options.globalConfigPath || GLOBAL_CONFIG_PATH;
-    this.agentsDir = options.agentsDir || AGENTS_DIR;
-    this.legacyGlobalSettingsPath = options.legacyGlobalSettingsPath || LEGACY_GLOBAL_SETTINGS_PATH;
-    this.globalMcpConfigPath = options.globalMcpConfigPath || GLOBAL_MCP_CONFIG_PATH;
+    this.globalConfigPath = options.globalConfigPath || defaultGlobalConfigPath();
+    this.agentsDir = options.agentsDir || defaultAgentsDir();
+    this.legacyGlobalSettingsPath = options.legacyGlobalSettingsPath || defaultLegacyGlobalSettingsPath();
+    this.globalMcpConfigPath = options.globalMcpConfigPath || defaultGlobalMcpConfigPath();
     this.configuredMcpServerNamesOverride = options.mcpServerNames
       ? [...new Set(options.mcpServerNames.map((name) => name.trim()).filter((name) => name.length > 0))]
       : null;

--- a/src/test.ts
+++ b/src/test.ts
@@ -1022,4 +1022,42 @@ runTest("Permission forwarding rejects unresolved sentinel session ids", () => {
   assert.equal(targetSessionId, null);
 });
 
+// ---------------------------------------------------------------------------
+// PI_CODING_AGENT_DIR support
+// ---------------------------------------------------------------------------
+
+runTest("PermissionManager reads config from PI_CODING_AGENT_DIR when set", () => {
+  const baseDir = mkdtempSync(join(tmpdir(), "pi-permission-system-envdir-"));
+  const agentsDir = join(baseDir, "agents");
+  mkdirSync(agentsDir, { recursive: true });
+
+  const config: GlobalPermissionConfig = {
+    defaultPolicy: { tools: "deny", bash: "deny", mcp: "deny", skills: "deny", special: "deny" },
+    tools: { read: "allow" },
+    bash: {},
+    mcp: {},
+    skills: {},
+    special: {},
+  };
+  writeFileSync(join(baseDir, "pi-permissions.jsonc"), JSON.stringify(config), "utf8");
+
+  const original = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = baseDir;
+  try {
+    const manager = new PermissionManager();
+    const result = manager.checkPermission("read", {});
+    assert.equal(result.state, "allow");
+
+    const result2 = manager.checkPermission("write", {});
+    assert.equal(result2.state, "deny");
+  } finally {
+    if (original !== undefined) {
+      process.env.PI_CODING_AGENT_DIR = original;
+    } else {
+      delete process.env.PI_CODING_AGENT_DIR;
+    }
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+});
+
 console.log("All permission system tests passed.");


### PR DESCRIPTION
## Summary

Replace all hardcoded `~/.pi/agent` paths with pi's `getAgentDir()` helper
so the extension respects the `PI_CODING_AGENT_DIR` environment variable.

## Changes

- **permission-manager.ts** — Replace hardcoded path constants with lazy
  functions calling `getAgentDir()`. Add integration test that sets
  `PI_CODING_AGENT_DIR` to a temp dir and verifies `PermissionManager`
  reads config from there.
- **src/index.ts** — Replace hardcoded `PI_AGENT_DIR` with `getAgentDir()`
  for session and subagent directory paths.
- **README.md** — Document that all `~/.pi/agent` paths are defaults and
  follow `PI_CODING_AGENT_DIR` when set.