### PR TITLE
Add project-level permissions configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -881,6 +881,33 @@ async function confirmPermission(ctx: ExtensionContext, message: string): Promis
   return waitForForwardedPermissionApproval(ctx, message);
 }
 
+function derivePiProjectPaths(cwd: string | undefined | null): {
+  projectGlobalConfigPath: string;
+  projectAgentsDir: string;
+} | null {
+  if (!cwd) {
+    return null;
+  }
+
+  const projectAgentRoot = join(cwd, ".pi", "agent");
+  return {
+    projectGlobalConfigPath: join(projectAgentRoot, "pi-permissions.jsonc"),
+    projectAgentsDir: join(projectAgentRoot, "agents"),
+  };
+}
+
+function createPermissionManagerForCwd(cwd: string | undefined | null): PermissionManager {
+  const projectPaths = derivePiProjectPaths(cwd);
+  if (!projectPaths) {
+    return new PermissionManager();
+  }
+
+  return new PermissionManager({
+    projectGlobalConfigPath: projectPaths.projectGlobalConfigPath,
+    projectAgentsDir: projectPaths.projectAgentsDir,
+  });
+}
+
 export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
   let permissionManager = new PermissionManager();
   let activeSkillEntries: SkillPromptEntry[] = [];
@@ -1133,7 +1160,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
   pi.on("session_start", async (_event, ctx) => {
     runtimeContext = ctx;
     refreshExtensionConfig(ctx);
-    permissionManager = new PermissionManager();
+    permissionManager = createPermissionManagerForCwd(ctx.cwd);
     activeSkillEntries = [];
     lastKnownActiveAgentName = getActiveAgentName(ctx);
     startForwardedPermissionPolling(ctx);
@@ -1142,6 +1169,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
   pi.on("session_switch", async (_event, ctx) => {
     runtimeContext = ctx;
     refreshExtensionConfig(ctx);
+    permissionManager = createPermissionManagerForCwd(ctx.cwd);
     activeSkillEntries = [];
     lastKnownActiveAgentName = getActiveAgentName(ctx);
     startForwardedPermissionPolling(ctx);

--- a/src/permission-manager.ts
+++ b/src/permission-manager.ts
@@ -424,11 +424,15 @@ function getFileStamp(path: string): string {
 export class PermissionManager {
   private readonly globalConfigPath: string;
   private readonly agentsDir: string;
+  private readonly projectGlobalConfigPath: string | null;
+  private readonly projectAgentsDir: string | null;
   private readonly legacyGlobalSettingsPath: string;
   private readonly globalMcpConfigPath: string;
   private readonly configuredMcpServerNamesOverride: readonly string[] | null;
   private globalConfigCache: FileCacheEntry<GlobalPermissionConfig> | null = null;
+  private projectGlobalConfigCache: FileCacheEntry<AgentPermissions> | null = null;
   private readonly agentConfigCache = new Map<string, FileCacheEntry<AgentPermissions>>();
+  private readonly projectAgentConfigCache = new Map<string, FileCacheEntry<AgentPermissions>>();
   private readonly resolvedPermissionsCache = new Map<string, FileCacheEntry<ResolvedPermissions>>();
   private configuredMcpServerNamesCache: FileCacheEntry<readonly string[]> | null = null;
 
@@ -436,6 +440,8 @@ export class PermissionManager {
     options: {
       globalConfigPath?: string;
       agentsDir?: string;
+      projectGlobalConfigPath?: string;
+      projectAgentsDir?: string;
       legacyGlobalSettingsPath?: string;
       globalMcpConfigPath?: string;
       mcpServerNames?: readonly string[];
@@ -443,6 +449,8 @@ export class PermissionManager {
   ) {
     this.globalConfigPath = options.globalConfigPath || GLOBAL_CONFIG_PATH;
     this.agentsDir = options.agentsDir || AGENTS_DIR;
+    this.projectGlobalConfigPath = options.projectGlobalConfigPath || null;
+    this.projectAgentsDir = options.projectAgentsDir || null;
     this.legacyGlobalSettingsPath = options.legacyGlobalSettingsPath || LEGACY_GLOBAL_SETTINGS_PATH;
     this.globalMcpConfigPath = options.globalMcpConfigPath || GLOBAL_MCP_CONFIG_PATH;
     this.configuredMcpServerNamesOverride = options.mcpServerNames
@@ -478,14 +486,41 @@ export class PermissionManager {
     return value;
   }
 
-  private loadAgentPermissions(agentName?: string): AgentPermissions {
-    if (!agentName) {
+  private loadProjectGlobalConfig(): AgentPermissions {
+    if (!this.projectGlobalConfigPath) {
       return {};
     }
 
-    const filePath = join(this.agentsDir, `${agentName}.md`);
+    const stamp = getFileStamp(this.projectGlobalConfigPath);
+    if (this.projectGlobalConfigCache?.stamp === stamp) {
+      return this.projectGlobalConfigCache.value;
+    }
+
+    let value: AgentPermissions;
+    try {
+      const raw = readFileSync(this.projectGlobalConfigPath, "utf-8");
+      const parsed = JSON.parse(stripJsonComments(raw)) as unknown;
+      value = normalizeRawPermission(parsed);
+    } catch {
+      value = {};
+    }
+
+    this.projectGlobalConfigCache = { stamp, value };
+    return value;
+  }
+
+  private loadAgentPermissionsFrom(
+    dir: string | null,
+    cache: Map<string, FileCacheEntry<AgentPermissions>>,
+    agentName?: string,
+  ): AgentPermissions {
+    if (!dir || !agentName) {
+      return {};
+    }
+
+    const filePath = join(dir, `${agentName}.md`);
     const stamp = getFileStamp(filePath);
-    const cached = this.agentConfigCache.get(agentName);
+    const cached = cache.get(agentName);
     if (cached?.stamp === stamp) {
       return cached.value;
     }
@@ -504,8 +539,16 @@ export class PermissionManager {
       value = {};
     }
 
-    this.agentConfigCache.set(agentName, { stamp, value });
+    cache.set(agentName, { stamp, value });
     return value;
+  }
+
+  private loadAgentPermissions(agentName?: string): AgentPermissions {
+    return this.loadAgentPermissionsFrom(this.agentsDir, this.agentConfigCache, agentName);
+  }
+
+  private loadProjectAgentPermissions(agentName?: string): AgentPermissions {
+    return this.loadAgentPermissionsFrom(this.projectAgentsDir, this.projectAgentConfigCache, agentName);
   }
 
   private mergePermissions(globalConfig: GlobalPermissionConfig, agentConfig: AgentPermissions): GlobalPermissionConfig {
@@ -540,24 +583,61 @@ export class PermissionManager {
   private resolvePermissions(agentName?: string): ResolvedPermissions {
     const cacheKey = agentName || "__global__";
     const agentStamp = agentName ? getFileStamp(join(this.agentsDir, `${agentName}.md`)) : "missing";
-    const stamp = `${getFileStamp(this.globalConfigPath)}|${agentStamp}`;
+    const projectStamp = this.projectGlobalConfigPath ? getFileStamp(this.projectGlobalConfigPath) : "none";
+    const projectAgentStamp =
+      this.projectAgentsDir && agentName ? getFileStamp(join(this.projectAgentsDir, `${agentName}.md`)) : "none";
+    const stamp = `${getFileStamp(this.globalConfigPath)}|${projectStamp}|${agentStamp}|${projectAgentStamp}`;
     const cached = this.resolvedPermissionsCache.get(cacheKey);
     if (cached?.stamp === stamp) {
       return cached.value;
     }
 
     const globalConfig = this.loadGlobalConfig();
+    const projectConfig = this.loadProjectGlobalConfig();
     const agentConfig = this.loadAgentPermissions(agentName);
-    const merged = this.mergePermissions(globalConfig, agentConfig);
-    const bashDefault = agentConfig.tools?.bash || merged.tools?.bash || merged.defaultPolicy.bash;
+    const projectAgentConfig = this.loadProjectAgentPermissions(agentName);
+
+    const mergedWithProject = this.mergePermissions(globalConfig, projectConfig);
+    const mergedWithAgent = this.mergePermissions(mergedWithProject, agentConfig);
+    const merged = this.mergePermissions(mergedWithAgent, projectAgentConfig);
+
+    const bashDefault =
+      projectAgentConfig.tools?.bash
+      || agentConfig.tools?.bash
+      || projectConfig.tools?.bash
+      || merged.tools?.bash
+      || merged.defaultPolicy.bash;
     const value: ResolvedPermissions = {
       globalConfig,
       agentConfig,
       merged,
-      compiledSpecial: compilePermissionPatternsFromSources(globalConfig.special, agentConfig.special),
-      compiledSkills: compilePermissionPatternsFromSources(globalConfig.skills, agentConfig.skills),
-      compiledMcp: compilePermissionPatternsFromSources(globalConfig.mcp, agentConfig.mcp),
-      bashFilter: new BashFilter(compilePermissionPatternsFromSources(globalConfig.bash, agentConfig.bash), bashDefault),
+      compiledSpecial: compilePermissionPatternsFromSources(
+        globalConfig.special,
+        projectConfig.special,
+        agentConfig.special,
+        projectAgentConfig.special,
+      ),
+      compiledSkills: compilePermissionPatternsFromSources(
+        globalConfig.skills,
+        projectConfig.skills,
+        agentConfig.skills,
+        projectAgentConfig.skills,
+      ),
+      compiledMcp: compilePermissionPatternsFromSources(
+        globalConfig.mcp,
+        projectConfig.mcp,
+        agentConfig.mcp,
+        projectAgentConfig.mcp,
+      ),
+      bashFilter: new BashFilter(
+        compilePermissionPatternsFromSources(
+          globalConfig.bash,
+          projectConfig.bash,
+          agentConfig.bash,
+          projectAgentConfig.bash,
+        ),
+        bashDefault,
+      ),
     };
 
     this.resolvedPermissionsCache.set(cacheKey, { stamp, value });

--- a/src/test.ts
+++ b/src/test.ts
@@ -15,7 +15,7 @@ import { PermissionManager } from "./permission-manager.js";
 import { checkRequestedToolRegistration, getToolNameFromValue } from "./tool-registry.js";
 import { getPermissionSystemStatus } from "./status.js";
 import { sanitizeAvailableToolsSection } from "./system-prompt-sanitizer.js";
-import type { GlobalPermissionConfig } from "./types.js";
+import type { AgentPermissions, GlobalPermissionConfig } from "./types.js";
 import { canResolveAskPermissionRequest, shouldAutoApprovePermissionState } from "./yolo-mode.js";
 
 type CreateManagerOptions = {
@@ -1020,6 +1020,265 @@ runTest("Permission forwarding rejects unresolved sentinel session ids", () => {
   });
 
   assert.equal(targetSessionId, null);
+});
+
+type CreateManagerWithProjectOptions = CreateManagerOptions & {
+  projectConfig?: AgentPermissions;
+  projectAgentFiles?: Record<string, string>;
+};
+
+function createManagerWithProject(
+  config: GlobalPermissionConfig,
+  agentFiles: Record<string, string> = {},
+  options: CreateManagerWithProjectOptions = {},
+) {
+  const baseDir = mkdtempSync(join(tmpdir(), "pi-permission-system-proj-test-"));
+  const globalConfigPath = join(baseDir, "pi-permissions.jsonc");
+  const agentsDir = join(baseDir, "agents");
+  const projectRoot = join(baseDir, "project");
+  const projectGlobalConfigPath = join(projectRoot, "pi-permissions.jsonc");
+  const projectAgentsDir = join(projectRoot, "agents");
+
+  mkdirSync(agentsDir, { recursive: true });
+  mkdirSync(projectAgentsDir, { recursive: true });
+
+  writeFileSync(globalConfigPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  if (options.projectConfig) {
+    writeFileSync(projectGlobalConfigPath, `${JSON.stringify(options.projectConfig, null, 2)}\n`, "utf8");
+  }
+
+  for (const [name, content] of Object.entries(agentFiles)) {
+    writeFileSync(join(agentsDir, `${name}.md`), content, "utf8");
+  }
+
+  for (const [name, content] of Object.entries(options.projectAgentFiles ?? {})) {
+    writeFileSync(join(projectAgentsDir, `${name}.md`), content, "utf8");
+  }
+
+  const manager = new PermissionManager({
+    globalConfigPath,
+    agentsDir,
+    projectGlobalConfigPath,
+    projectAgentsDir,
+    mcpServerNames: options.mcpServerNames,
+  });
+
+  return {
+    manager,
+    cleanup: (): void => {
+      rmSync(baseDir, { recursive: true, force: true });
+    },
+  };
+}
+
+runTest("Project-level config overrides base bash patterns", () => {
+  const { manager, cleanup } = createManagerWithProject(
+    {
+      defaultPolicy: {
+        tools: "allow",
+        bash: "ask",
+        mcp: "ask",
+        skills: "ask",
+        special: "ask",
+      },
+      bash: {
+        "rm -rf *": "deny",
+      },
+    },
+    {},
+    {
+      projectConfig: {
+        bash: {
+          "rm -rf build": "allow",
+        },
+      },
+    },
+  );
+
+  try {
+    const allowed = manager.checkPermission("bash", { command: "rm -rf build" });
+    assert.equal(allowed.state, "allow");
+    assert.equal(allowed.matchedPattern, "rm -rf build");
+
+    const denied = manager.checkPermission("bash", { command: "rm -rf node_modules" });
+    assert.equal(denied.state, "deny");
+    assert.equal(denied.matchedPattern, "rm -rf *");
+  } finally {
+    cleanup();
+  }
+});
+
+runTest("System-agent config overrides project-level bash patterns", () => {
+  const { manager, cleanup } = createManagerWithProject(
+    {
+      defaultPolicy: {
+        tools: "allow",
+        bash: "ask",
+        mcp: "ask",
+        skills: "ask",
+        special: "ask",
+      },
+    },
+    {
+      reviewer: `---
+name: reviewer
+permission:
+  bash:
+    "git log *": allow
+---
+`,
+    },
+    {
+      projectConfig: {
+        bash: {
+          "git *": "deny",
+        },
+      },
+    },
+  );
+
+  try {
+    const allowed = manager.checkPermission("bash", { command: "git log --oneline" }, "reviewer");
+    assert.equal(allowed.state, "allow");
+    assert.equal(allowed.matchedPattern, "git log *");
+
+    const denied = manager.checkPermission("bash", { command: "git status" }, "reviewer");
+    assert.equal(denied.state, "deny");
+    assert.equal(denied.matchedPattern, "git *");
+  } finally {
+    cleanup();
+  }
+});
+
+runTest("Project-agent config overrides system-agent tool rules", () => {
+  const { manager, cleanup } = createManagerWithProject(
+    {
+      defaultPolicy: {
+        tools: "ask",
+        bash: "ask",
+        mcp: "ask",
+        skills: "ask",
+        special: "ask",
+      },
+    },
+    {
+      reviewer: `---
+name: reviewer
+permission:
+  tools:
+    read: deny
+---
+`,
+    },
+    {
+      projectAgentFiles: {
+        reviewer: `---
+name: reviewer
+permission:
+  tools:
+    read: allow
+---
+`,
+      },
+    },
+  );
+
+  try {
+    const result = manager.checkPermission("read", {}, "reviewer");
+    assert.equal(result.state, "allow");
+    assert.equal(result.source, "tool");
+  } finally {
+    cleanup();
+  }
+});
+
+runTest("Full precedence chain base < project < system-agent < project-agent for defaultPolicy", () => {
+  const { manager, cleanup } = createManagerWithProject(
+    {
+      defaultPolicy: {
+        tools: "deny",
+        bash: "ask",
+        mcp: "ask",
+        skills: "ask",
+        special: "ask",
+      },
+    },
+    {
+      reviewer: `---
+name: reviewer
+permission:
+  defaultPolicy:
+    tools: ask
+---
+`,
+    },
+    {
+      projectConfig: {
+        defaultPolicy: {
+          tools: "allow",
+        },
+      },
+      projectAgentFiles: {
+        reviewer: `---
+name: reviewer
+permission:
+  defaultPolicy:
+    tools: deny
+---
+`,
+      },
+    },
+  );
+
+  try {
+    const reviewerResult = manager.checkPermission("custom_extension_tool", {}, "reviewer");
+    assert.equal(reviewerResult.state, "deny");
+    assert.equal(reviewerResult.source, "default");
+
+    const globalResult = manager.checkPermission("custom_extension_tool", {});
+    assert.equal(globalResult.state, "allow");
+    assert.equal(globalResult.source, "default");
+  } finally {
+    cleanup();
+  }
+});
+
+runTest("Project-agent applies even without a matching system-agent file", () => {
+  const { manager, cleanup } = createManagerWithProject(
+    {
+      defaultPolicy: {
+        tools: "allow",
+        bash: "ask",
+        mcp: "ask",
+        skills: "ask",
+        special: "ask",
+      },
+    },
+    {},
+    {
+      projectAgentFiles: {
+        reviewer: `---
+name: reviewer
+permission:
+  tools:
+    read: deny
+---
+`,
+      },
+    },
+  );
+
+  try {
+    const agentResult = manager.checkPermission("read", {}, "reviewer");
+    assert.equal(agentResult.state, "deny");
+    assert.equal(agentResult.source, "tool");
+
+    const globalResult = manager.checkPermission("read", {});
+    assert.equal(globalResult.state, "allow");
+    assert.equal(globalResult.source, "tool");
+  } finally {
+    cleanup();
+  }
 });
 
 console.log("All permission system tests passed.");


### PR DESCRIPTION
This allows adding `.pi/agent/pi-permissions.jsonc` and `.pi/agent/agents` files to project `.pi` directories, allowing you to specify permissions on a per-project basis. The overrides go `base permissions.jsonc < project .jsonc < system agents < project agents`.

There are a number of new tests introduced:
- Project beats base on overlapping bash patterns.
- System-agent beats project on overlapping bash patterns.
- Project-agent beats system-agent on tools.read.
- With all four layers setting defaultPolicy.tools differently, project-agent wins when an agent is active and project wins otherwise.
- Project-agent rules apply even when no system-agent file exists.