### PR TITLE
Show tool input in ask prompt for generic tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -430,7 +430,31 @@ function formatUserDeniedReason(result: PermissionCheckResult, denialReason?: st
   return `${base}${reasonSuffix} ${formatPermissionHardStopHint(result)}`;
 }
 
-function formatAskPrompt(result: PermissionCheckResult, agentName?: string): string {
+function formatToolInputForPrompt(input: unknown): string {
+  if (input === undefined || input === null) {
+    return "";
+  }
+
+  if (typeof input === "object" && !Array.isArray(input) && Object.keys(input as Record<string, unknown>).length === 0) {
+    return "";
+  }
+
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(input);
+  } catch {
+    return "";
+  }
+
+  if (!serialized || serialized === "{}" || serialized === "null") {
+    return "";
+  }
+
+  const MAX = 200;
+  return serialized.length > MAX ? `${serialized.slice(0, MAX)}…` : serialized;
+}
+
+function formatAskPrompt(result: PermissionCheckResult, agentName?: string, input?: unknown): string {
   const subject = agentName ? `Agent '${agentName}'` : "Current agent";
 
   if (result.toolName === "bash") {
@@ -444,7 +468,9 @@ function formatAskPrompt(result: PermissionCheckResult, agentName?: string): str
   }
 
   const patternInfo = result.matchedPattern ? ` (matched '${result.matchedPattern}')` : "";
-  return `${subject} requested tool '${result.toolName}'${patternInfo}. Allow this call?`;
+  const inputPreview = formatToolInputForPrompt(input);
+  const inputSuffix = inputPreview ? ` with input ${inputPreview}` : "";
+  return `${subject} requested tool '${result.toolName}'${patternInfo}${inputSuffix}. Allow this call?`;
 }
 
 function formatSkillAskPrompt(skillName: string, agentName?: string): string {
@@ -1454,7 +1480,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
           ? "Using tool 'mcp' requires approval, but no interactive UI is available."
           : `Using tool '${toolName}' requires approval, but no interactive UI is available.`;
 
-      const message = formatAskPrompt(check, agentName ?? undefined);
+      const message = formatAskPrompt(check, agentName ?? undefined, input);
       if (!canRequestPermissionConfirmation(ctx)) {
         writeReviewLog("permission_request.blocked", {
           source: "tool_call",


### PR DESCRIPTION
## Summary

- `formatAskPrompt` previously rendered only the tool name in its generic fallback branch, so any tool other than `bash` or a registered `mcp` proxy tool prompted with no visible arguments. This included tools registered by extensions that surface each bridged MCP tool as a top-level pi tool (e.g., an extension that registers a server's `weather_lookup` directly instead of going through a single `mcp` proxy). Users were asked to approve calls without being able to see what was about to run.
- Added `formatToolInputForPrompt(input)` that returns a short JSON preview of the input: truncated at 200 characters with a trailing ellipsis, and suppressed when the input is empty, null, or unserializable.
- `formatAskPrompt` now accepts an optional `input` parameter. Only the generic fallback branch uses it, appending ` with input <preview>` after the tool name. Behavior for the `bash` and `mcp-target` branches is unchanged. The single call site inside the `tool_call` handler passes the already-available `input`.

### Before / After

Before: `Current agent requested tool 'weather_lookup'. Allow this call?`

After: `Current agent requested tool 'weather_lookup' with input {"city":"Chicago","units":"metric"}. Allow this call?`

## Test plan

- [x] `npm run test` — all 27 existing tests still pass
- [x] `npm run build` — clean
- [x] Verified end-to-end in an interactive pi session: an extension that registers MCP-server-backed tools by name (not through the built-in `mcp` proxy) now surfaces the input in the permission dialog
- [ ] Reviewer: consider the 200-char cap — generous enough for common tools, short enough to not overwhelm the dialog