### PR TITLE
feat(special): enforce external_directory CWD boundary in tool_call handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1431,6 +1431,73 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
       }
     }
 
+    if (ctx.cwd && PATH_BEARING_TOOLS.has(toolName)) {
+      const toolInput = getEventInput(event);
+      const inputRecord = toRecord(toolInput);
+      const rawPath = typeof inputRecord.path === "string" ? inputRecord.path.trim() : null;
+
+      if (rawPath) {
+        const normalizedCwd = normalizeFilesystemPath(ctx.cwd);
+        const normalizedFilePath = normalizePathForComparison(rawPath, ctx.cwd);
+
+        if (normalizedFilePath && !isPathWithinDirectory(normalizedFilePath, normalizedCwd)) {
+          const extCheck = permissionManager.checkPermission("external_directory", {}, agentName ?? undefined);
+
+          if (extCheck.state === "deny") {
+            writeReviewLog("permission_request.blocked", {
+              source: "tool_call",
+              toolCallId: event.toolCallId,
+              toolName,
+              agentName,
+              path: rawPath,
+              resolution: "policy_denied",
+            });
+            return {
+              block: true,
+              reason: formatExternalDirectoryDenyReason(rawPath, ctx.cwd, agentName ?? undefined),
+            };
+          }
+
+          if (extCheck.state === "ask") {
+            const message = formatExternalDirectoryAskPrompt(rawPath, ctx.cwd, agentName ?? undefined);
+            if (!canRequestPermissionConfirmation(ctx)) {
+              writeReviewLog("permission_request.blocked", {
+                source: "tool_call",
+                toolCallId: event.toolCallId,
+                toolName,
+                agentName,
+                path: rawPath,
+                message,
+                resolution: "confirmation_unavailable",
+              });
+              return {
+                block: true,
+                reason: `Accessing '${rawPath}' outside the working directory requires approval, but no interactive UI is available.`,
+              };
+            }
+
+            const extDecision = await promptPermission(ctx, {
+              requestId: event.toolCallId,
+              source: "tool_call",
+              agentName,
+              message,
+              toolCallId: event.toolCallId,
+              toolName,
+              path: rawPath,
+            });
+
+            if (!extDecision.approved) {
+              return {
+                block: true,
+                reason: formatExternalDirectoryUserDeniedReason(rawPath, extDecision.denialReason),
+              };
+            }
+          }
+          // state === "allow" → fall through to normal permission check
+        }
+      }
+    }
+
     const input = getEventInput(event);
     const check = permissionManager.checkPermission(toolName, input, agentName ?? undefined);
     const permissionLogContext = getPermissionLogContext(check);

--- a/tests/permission-system.test.ts
+++ b/tests/permission-system.test.ts
@@ -1414,4 +1414,144 @@ runTest("PermissionManager reads config from PI_CODING_AGENT_DIR when set", () =
   }
 });
 
+// ---------------------------------------------------------------------------
+// external_directory special permission
+// ---------------------------------------------------------------------------
+
+runTest("external_directory permission falls back to special default policy when not explicitly configured", () => {
+  const { manager, cleanup } = createManager({
+    defaultPolicy: {
+      tools: "allow",
+      bash: "allow",
+      mcp: "allow",
+      skills: "allow",
+      special: "ask",
+    },
+  });
+
+  try {
+    const result = manager.checkPermission("external_directory", {});
+    assert.equal(result.state, "ask");
+    assert.equal(result.source, "special");
+    assert.equal(result.matchedPattern, undefined);
+  } finally {
+    cleanup();
+  }
+});
+
+runTest("external_directory permission respects explicit deny in special config", () => {
+  const { manager, cleanup } = createManager({
+    defaultPolicy: {
+      tools: "allow",
+      bash: "allow",
+      mcp: "allow",
+      skills: "allow",
+      special: "ask",
+    },
+    special: {
+      external_directory: "deny",
+    },
+  });
+
+  try {
+    const result = manager.checkPermission("external_directory", {});
+    assert.equal(result.state, "deny");
+    assert.equal(result.source, "special");
+    assert.equal(result.matchedPattern, "external_directory");
+  } finally {
+    cleanup();
+  }
+});
+
+runTest("external_directory permission can be explicitly allowed", () => {
+  const { manager, cleanup } = createManager({
+    defaultPolicy: {
+      tools: "allow",
+      bash: "allow",
+      mcp: "allow",
+      skills: "allow",
+      special: "deny",
+    },
+    special: {
+      external_directory: "allow",
+    },
+  });
+
+  try {
+    const result = manager.checkPermission("external_directory", {});
+    assert.equal(result.state, "allow");
+    assert.equal(result.source, "special");
+    assert.equal(result.matchedPattern, "external_directory");
+  } finally {
+    cleanup();
+  }
+});
+
+runTest("external_directory permission respects per-agent override", () => {
+  const { manager, cleanup } = createManager(
+    {
+      defaultPolicy: {
+        tools: "allow",
+        bash: "allow",
+        mcp: "allow",
+        skills: "allow",
+        special: "ask",
+      },
+      special: {
+        external_directory: "deny",
+      },
+    },
+    {
+      trusted: `---
+name: trusted
+permission:
+  special:
+    external_directory: allow
+---
+`,
+    },
+  );
+
+  try {
+    // Global policy denies external_directory
+    const globalResult = manager.checkPermission("external_directory", {});
+    assert.equal(globalResult.state, "deny");
+
+    // Trusted agent overrides to allow
+    const agentResult = manager.checkPermission("external_directory", {}, "trusted");
+    assert.equal(agentResult.state, "allow");
+    assert.equal(agentResult.source, "special");
+  } finally {
+    cleanup();
+  }
+});
+
+runTest("external_directory permission is independent of doom_loop in the same special config", () => {
+  const { manager, cleanup } = createManager({
+    defaultPolicy: {
+      tools: "allow",
+      bash: "allow",
+      mcp: "allow",
+      skills: "allow",
+      special: "ask",
+    },
+    special: {
+      doom_loop: "deny",
+      external_directory: "allow",
+    },
+  });
+
+  try {
+    const doomResult = manager.checkPermission("doom_loop", {});
+    assert.equal(doomResult.state, "deny");
+    assert.equal(doomResult.matchedPattern, "doom_loop");
+
+    const extResult = manager.checkPermission("external_directory", {});
+    assert.equal(extResult.state, "allow");
+    assert.equal(extResult.matchedPattern, "external_directory");
+  } finally {
+    cleanup();
+  }
+});
+
 console.log("All permission system tests passed.");


### PR DESCRIPTION
Hi @MasuRii — thanks for publishing pi-permission-system! It's a really well-structured project.

## Summary

This PR wires up the `external_directory` special permission that already exists in the schema and `PermissionManager` but was never enforced. With this change, any path-bearing tool call (`read`, `write`, `edit`, `find`, `grep`, `ls`) that targets a path outside `ctx.cwd` is gated by the `external_directory` permission — matching what OpenCode does with its `external_directory` permission.

## What it does

In the `tool_call` handler, for each tool call with an explicit `path` input:

1. Resolves the path to an absolute, normalized form using the existing `normalizePathForComparison` helper
2. Checks whether it falls outside `ctx.cwd` using the existing `isPathWithinDirectory` utility
3. If outside, evaluates `permissionManager.checkPermission("external_directory", ...)` and enforces the result:
   - **deny** → blocks with a policy-enforced reason
   - **ask** → prompts via `promptPermission` (with subagent forwarding support)
   - **allow** → falls through to the normal tool permission check

Tools with an optional `path` field (`find`, `grep`, `ls`) skip the check when no path is provided, since they default to the working directory.

The default policy for `external_directory` is `"ask"` (inherited from `defaultPolicy.special`), matching OpenCode's default behavior.

## What's included

- `PATH_BEARING_TOOLS` constant and three `formatExternalDirectory*` message helpers
- CWD boundary check in the `tool_call` handler (after skill-path validation, before the main tool permission check)
- 5 tests covering `external_directory` permission resolution through the special permission infrastructure