### PR TITLE
fix(events): listen on session_start instead of nonexistent session_switch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1294,7 +1294,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     }
   });
 
-  pi.on("session_switch", async (_event, ctx) => {
+  pi.on("session_start", async (_event, ctx) => {
     runtimeContext = ctx;
     refreshExtensionConfig(ctx);
     permissionManager = createPermissionManagerForCwd(ctx.cwd);


### PR DESCRIPTION
Hi @MasuRii — thanks again for the continued work on pi-permission-system, and for merging the `external_directory` PR!

## Summary

The post-session-switch refresh handler was registered against the event name `'session_switch'`, which has never existed in `@mariozechner/pi-coding-agent`. Pi emits `'session_start'` (with `reason: "startup" | "reload" | "new" | "resume" | "fork"`) for both the initial session and every subsequent switch, fork, or resume. That is the event this handler was always meant to observe.

## Symptoms before this fix

- `runtimeContext` was never refreshed after the user switched sessions, so subsequent permission checks could resolve against a stale `cwd`
- `permissionManager` was never recreated for the new session's `cwd`, meaning project-local `pi-permissions.jsonc` files in the destination workspace were ignored until pi was restarted
- The before-agent-start cache was never invalidated on switch, so a freshly switched session could reuse cached prompt state from the previous session
- Forwarded permission polling was never restarted with the new session context

## How we found it

The bug was hidden by `types-shims.d.ts`, which typed `pi.on` as `on(event: string, ...)` and accepted any string literal. Replacing the shim with the real `@mariozechner/pi-coding-agent` type package surfaces this as a `TS2769` overload mismatch on the unknown event name — making the compiler catch any future misspellings of event names.

## What's included

- One-line change in `src/index.ts`: `'session_switch'` → `'session_start'`