### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Type check / lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
Hi @MasuRii!

## Summary

Adds a minimal GitHub Actions CI workflow that runs on every push to `main` and on all pull requests.

> **Note:** This PR adds a basic workflow with type-check and test steps. If #14 (Biome tooling) is merged first, the workflow there already includes `lint` and `lint:md` steps as well — in that case this PR can be skipped or closed in favour of the one bundled with #14.

## What it does

On each push to `main` and each PR:

1. Checks out the repo
2. Sets up Node 24 with `npm` cache
3. Runs `npm ci` (installs from the committed lockfile)
4. Runs `npm run build` (type-check)
5. Runs `npm test`

## What's included

- `.github/workflows/ci.yml`: new workflow file (28 lines)