### PR TITLE
Fix yolo mode being on by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "index.ts",
     "src",
     "tests",
-    "config.json",
     "config/config.example.json",
     "schemas/permissions.schema.json",
     "README.md",


### PR DESCRIPTION
The documentation states yolo mode is off by default. In reality, it's been on by default since 0.3.0, due to a config file being included in the package that is published, which should have been omitted.

The config file first showed up in 0.2.1:
``` bash
$ curl https://unpkg.com/pi-permission-system@0.2.1/config.json
{
  "debugLog": false,
  "permissionReviewLog": true
}
```
In 0.3.0, it set `"yoloMode": true`
``` bash
$ curl https://unpkg.com/pi-permission-system@0.3.0/config.json
{
  "debugLog": false,
  "permissionReviewLog": true,
  "yoloMode": true
}
```
While the application code does indeed default to having yolo mode off, the presence of this config file means it's actually on by default. It should be omitted from the package when it is published.