### PR TITLE
add toggle shortcut for YOLO mode and make UI status message configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,17 @@ The extension integrates via Pi's lifecycle hooks:
 
 **Location:** global Pi extension config (default: `~/.pi/agent/extensions/pi-permission-system/config.json`, respects `PI_CODING_AGENT_DIR`)
 
-The extension creates this file automatically when it is missing. It controls only extension-local logging behavior:
+The extension creates this file automatically when it is missing. It controls extension-local logging, yolo mode, status text, and shortcut bindings:
 
 ```json
 {
   "debugLog": false,
   "permissionReviewLog": true,
   "yoloMode": false,
-  "yoloStatusMessage": "YOLO mode enabled 🚀 "
+  "yoloStatusMessage": "YOLO mode enabled 🚀 ",
+  "shortcutBindings": {
+    "toggleYoloMode": "f8"
+  }
 }
 ```
 
@@ -119,6 +122,7 @@ The extension creates this file automatically when it is missing. It controls on
 | `permissionReviewLog` | `true` | Enables the permission request/denial review log at `logs/pi-permission-system-permission-review.jsonl` |
 | `yoloMode` | `false` | Auto-approves `ask` results instead of prompting when yolo mode is enabled |
 | `yoloStatusMessage` | `"YOLO mode enabled 🚀 "` | Status text shown when yolo mode is enabled. Set to `null` to hide status entirely. |
+| `shortcutBindings.toggleYoloMode` | `"f8"` | Keyboard shortcut that toggles yolo mode. Set to `null` to disable shortcut registration. |
 
 Both logs write to files only under the extension directory. No debug output is printed to the terminal.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ The extension creates this file automatically when it is missing. It controls on
 {
   "debugLog": false,
   "permissionReviewLog": true,
-  "yoloMode": false
+  "yoloMode": false,
+  "yoloStatusMessage": "YOLO mode enabled 🚀 "
 }
 ```
 
@@ -117,6 +118,7 @@ The extension creates this file automatically when it is missing. It controls on
 | `debugLog` | `false` | Enables verbose diagnostic logging to `logs/pi-permission-system-debug.jsonl` |
 | `permissionReviewLog` | `true` | Enables the permission request/denial review log at `logs/pi-permission-system-permission-review.jsonl` |
 | `yoloMode` | `false` | Auto-approves `ask` results instead of prompting when yolo mode is enabled |
+| `yoloStatusMessage` | `"YOLO mode enabled 🚀 "` | Status text shown when yolo mode is enabled. Set to `null` to hide status entirely. |
 
 Both logs write to files only under the extension directory. No debug output is printed to the terminal.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "npx --yes -p typescript@5.7.3 tsc -p tsconfig.json --noCheck",
     "lint": "npm run build",
-    "test": "bun ./tests/permission-system.test.ts && bun ./tests/config-modal.test.ts",
+    "test": "bun ./tests/permission-system.test.ts && bun ./tests/config-modal.test.ts && bun ./tests/shortcuts.test.ts",
     "check": "npm run lint && npm run test"
   },
   "keywords": [

--- a/src/config-modal.ts
+++ b/src/config-modal.ts
@@ -44,6 +44,7 @@ function cloneDefaultConfig(): PermissionSystemExtensionConfig {
     debugLog: DEFAULT_EXTENSION_CONFIG.debugLog,
     permissionReviewLog: DEFAULT_EXTENSION_CONFIG.permissionReviewLog,
     yoloMode: DEFAULT_EXTENSION_CONFIG.yoloMode,
+    yoloStatusMessage: DEFAULT_EXTENSION_CONFIG.yoloStatusMessage,
   };
 }
 

--- a/src/config-modal.ts
+++ b/src/config-modal.ts
@@ -45,6 +45,9 @@ function cloneDefaultConfig(): PermissionSystemExtensionConfig {
     permissionReviewLog: DEFAULT_EXTENSION_CONFIG.permissionReviewLog,
     yoloMode: DEFAULT_EXTENSION_CONFIG.yoloMode,
     yoloStatusMessage: DEFAULT_EXTENSION_CONFIG.yoloStatusMessage,
+    shortcutBindings: {
+      toggleYoloMode: DEFAULT_EXTENSION_CONFIG.shortcutBindings.toggleYoloMode,
+    },
   };
 }
 

--- a/src/extension-config.ts
+++ b/src/extension-config.ts
@@ -10,6 +10,7 @@ export interface PermissionSystemExtensionConfig {
   debugLog: boolean;
   permissionReviewLog: boolean;
   yoloMode: boolean;
+  yoloStatusMessage: string | null;
 }
 
 export interface PermissionSystemConfigLoadResult {
@@ -27,6 +28,7 @@ export const DEFAULT_EXTENSION_CONFIG: PermissionSystemExtensionConfig = {
   debugLog: false,
   permissionReviewLog: true,
   yoloMode: false,
+  yoloStatusMessage: "YOLO mode enabled 🚀 ",
 };
 
 export function resolveExtensionRoot(moduleUrl = import.meta.url): string {
@@ -44,6 +46,7 @@ function cloneDefaultConfig(): PermissionSystemExtensionConfig {
     debugLog: DEFAULT_EXTENSION_CONFIG.debugLog,
     permissionReviewLog: DEFAULT_EXTENSION_CONFIG.permissionReviewLog,
     yoloMode: DEFAULT_EXTENSION_CONFIG.yoloMode,
+    yoloStatusMessage: DEFAULT_EXTENSION_CONFIG.yoloStatusMessage,
   };
 }
 
@@ -53,10 +56,19 @@ function createDefaultConfigContent(): string {
 
 export function normalizePermissionSystemConfig(raw: unknown): PermissionSystemExtensionConfig {
   const record = toRecord(raw);
+
+  let yoloStatusMessage = DEFAULT_EXTENSION_CONFIG.yoloStatusMessage;
+  if (record.yoloStatusMessage === null) {
+    yoloStatusMessage = null;
+  } else if (typeof record.yoloStatusMessage === "string") {
+    yoloStatusMessage = record.yoloStatusMessage;
+  }
+
   return {
     debugLog: record.debugLog === true,
     permissionReviewLog: record.permissionReviewLog !== false,
     yoloMode: record.yoloMode === true,
+    yoloStatusMessage,
   };
 }
 

--- a/src/extension-config.ts
+++ b/src/extension-config.ts
@@ -6,11 +6,16 @@ import { toRecord } from "./common.js";
 
 export const EXTENSION_ID = "pi-permission-system";
 
+export interface PermissionSystemShortcutBindings {
+  toggleYoloMode: string | null;
+}
+
 export interface PermissionSystemExtensionConfig {
   debugLog: boolean;
   permissionReviewLog: boolean;
   yoloMode: boolean;
   yoloStatusMessage: string | null;
+  shortcutBindings: PermissionSystemShortcutBindings;
 }
 
 export interface PermissionSystemConfigLoadResult {
@@ -29,6 +34,9 @@ export const DEFAULT_EXTENSION_CONFIG: PermissionSystemExtensionConfig = {
   permissionReviewLog: true,
   yoloMode: false,
   yoloStatusMessage: "YOLO mode enabled 🚀 ",
+  shortcutBindings: {
+    toggleYoloMode: "f8",
+  },
 };
 
 export function resolveExtensionRoot(moduleUrl = import.meta.url): string {
@@ -47,6 +55,9 @@ function cloneDefaultConfig(): PermissionSystemExtensionConfig {
     permissionReviewLog: DEFAULT_EXTENSION_CONFIG.permissionReviewLog,
     yoloMode: DEFAULT_EXTENSION_CONFIG.yoloMode,
     yoloStatusMessage: DEFAULT_EXTENSION_CONFIG.yoloStatusMessage,
+    shortcutBindings: {
+      toggleYoloMode: DEFAULT_EXTENSION_CONFIG.shortcutBindings.toggleYoloMode,
+    },
   };
 }
 
@@ -56,6 +67,15 @@ function createDefaultConfigContent(): string {
 
 export function normalizePermissionSystemConfig(raw: unknown): PermissionSystemExtensionConfig {
   const record = toRecord(raw);
+  const shortcutBindingsRecord = toRecord(record.shortcutBindings);
+
+  let toggleYoloMode = DEFAULT_EXTENSION_CONFIG.shortcutBindings.toggleYoloMode;
+  if (shortcutBindingsRecord.toggleYoloMode === null) {
+    toggleYoloMode = null;
+  } else if (typeof shortcutBindingsRecord.toggleYoloMode === "string") {
+    const normalizedShortcut = shortcutBindingsRecord.toggleYoloMode.trim();
+    toggleYoloMode = normalizedShortcut.length > 0 ? normalizedShortcut : null;
+  }
 
   let yoloStatusMessage = DEFAULT_EXTENSION_CONFIG.yoloStatusMessage;
   if (record.yoloStatusMessage === null) {
@@ -69,6 +89,9 @@ export function normalizePermissionSystemConfig(raw: unknown): PermissionSystemE
     permissionReviewLog: record.permissionReviewLog !== false,
     yoloMode: record.yoloMode === true,
     yoloStatusMessage,
+    shortcutBindings: {
+      toggleYoloMode,
+    },
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import type { PermissionCheckResult } from "./types.js";
 import { PERMISSION_SYSTEM_STATUS_KEY, syncPermissionSystemStatus } from "./status.js";
 import { canResolveAskPermissionRequest, shouldAutoApprovePermissionState } from "./yolo-mode.js";
 import { registerModelOptionCompatibilityGuard } from "./model-option-compatibility.js";
+import { registerConfiguredShortcuts, type ShortcutActionDefinition } from "./shortcuts.js";
 
 const PI_AGENT_DIR = getAgentDir();
 const SESSIONS_DIR = join(PI_AGENT_DIR, "sessions");
@@ -1061,7 +1062,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     });
   };
 
-  const saveExtensionConfig = (next: PermissionSystemExtensionConfig, ctx: ExtensionCommandContext): void => {
+  const saveExtensionConfig = (next: PermissionSystemExtensionConfig, ctx: ExtensionContext): void => {
     const normalized = normalizePermissionSystemConfig(next);
     const saved = savePermissionSystemConfig(normalized);
     if (!saved.success) {
@@ -1091,6 +1092,32 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     setConfig: saveExtensionConfig,
     getConfigPath: getPermissionSystemConfigPath,
   });
+
+  const shortcutActions: ShortcutActionDefinition[] = [
+    {
+      id: "toggleYoloMode",
+      description: "Toggle pi-permission-system YOLO mode",
+      getShortcut: (config) => config.shortcutBindings.toggleYoloMode,
+      handler: (ctx) => {
+        const nextConfig: PermissionSystemExtensionConfig = {
+          ...extensionConfig,
+          yoloMode: !extensionConfig.yoloMode,
+        };
+        saveExtensionConfig(nextConfig, ctx);
+        ctx.ui.notify(`YOLO mode ${nextConfig.yoloMode ? "enabled" : "disabled"}.`, "info");
+      },
+    },
+  ];
+
+  registerConfiguredShortcuts(
+    pi,
+    extensionConfig,
+    shortcutActions,
+    (message) => {
+      writeDebugLog("shortcut.register_failed", { message });
+      notifyWarning(message);
+    },
+  );
 
   const createPermissionRequestId = (prefix: string): string => {
     return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}-${process.pid}`;

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -1,0 +1,34 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+import type { PermissionSystemExtensionConfig } from "./extension-config.js";
+
+export type ShortcutActionDefinition = {
+  id: string;
+  description: string;
+  getShortcut: (config: PermissionSystemExtensionConfig) => string | null;
+  handler: (ctx: ExtensionContext) => Promise<void> | void;
+};
+
+export function registerConfiguredShortcuts(
+  pi: ExtensionAPI,
+  config: PermissionSystemExtensionConfig,
+  actions: readonly ShortcutActionDefinition[],
+  notifyWarning: (message: string) => void,
+): void {
+  for (const action of actions) {
+    const shortcut = action.getShortcut(config);
+    if (!shortcut) {
+      continue;
+    }
+
+    try {
+      pi.registerShortcut(shortcut, {
+        description: action.description,
+        handler: action.handler,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      notifyWarning(`Failed to register shortcut '${shortcut}' (${action.id}): ${message}`);
+    }
+  }
+}

--- a/src/status.ts
+++ b/src/status.ts
@@ -4,12 +4,15 @@ import { EXTENSION_ID, type PermissionSystemExtensionConfig } from "./extension-
 import { isYoloModeEnabled } from "./yolo-mode.js";
 
 export const PERMISSION_SYSTEM_STATUS_KEY = EXTENSION_ID;
-export const PERMISSION_SYSTEM_YOLO_STATUS_VALUE = "yolo";
 
 type PermissionStatusContext = Pick<ExtensionContext, "hasUI" | "ui"> | Pick<ExtensionCommandContext, "ui">;
 
 export function getPermissionSystemStatus(config: PermissionSystemExtensionConfig): string | undefined {
-  return isYoloModeEnabled(config) ? PERMISSION_SYSTEM_YOLO_STATUS_VALUE : undefined;
+  if (!isYoloModeEnabled(config)) {
+    return undefined;
+  }
+
+  return config.yoloStatusMessage ?? undefined;
 }
 
 export function syncPermissionSystemStatus(

--- a/src/types-shims.d.ts
+++ b/src/types-shims.d.ts
@@ -115,6 +115,13 @@ declare module "@mariozechner/pi-coding-agent" {
         handler: (args: string, ctx: ExtensionCommandContext) => Promise<void> | void;
       },
     ): void;
+    registerShortcut(
+      shortcut: string,
+      definition: {
+        description?: string;
+        handler: (ctx: ExtensionContext) => Promise<void> | void;
+      },
+    ): void;
     events: {
       emit(channel: string, payload: unknown): void;
     };

--- a/tests/permission-system.test.ts
+++ b/tests/permission-system.test.ts
@@ -9,7 +9,13 @@ import {
   createBeforeAgentStartPromptStateKey,
   shouldApplyCachedAgentStartState,
 } from "../src/before-agent-start-cache.js";
-import { CONFIG_PATH, DEFAULT_EXTENSION_CONFIG, loadPermissionSystemConfig, savePermissionSystemConfig } from "../src/extension-config.js";
+import {
+  CONFIG_PATH,
+  DEFAULT_EXTENSION_CONFIG,
+  loadPermissionSystemConfig,
+  normalizePermissionSystemConfig,
+  savePermissionSystemConfig,
+} from "../src/extension-config.js";
 import { createPermissionSystemLogger } from "../src/logging.js";
 import {
   createPermissionForwardingLocation,
@@ -251,6 +257,7 @@ runTest("Permission-system extension config loads yolo mode when explicitly enab
       debugLog: true,
       permissionReviewLog: false,
       yoloMode: true,
+      yoloStatusMessage: "YOLO mode enabled 🚀 ",
     });
   } finally {
     rmSync(baseDir, { recursive: true, force: true });
@@ -303,6 +310,7 @@ runTest("Permission-system extension config save persists normalized config", ()
       debugLog: true,
       permissionReviewLog: false,
       yoloMode: true,
+      yoloStatusMessage: "YOLO mode enabled 🚀 ",
     });
   } finally {
     rmSync(baseDir, { recursive: true, force: true });
@@ -356,8 +364,20 @@ runTest("Permission-system status is only exposed when yolo mode is enabled", ()
   assert.equal(getPermissionSystemStatus(DEFAULT_EXTENSION_CONFIG), undefined);
   assert.equal(
     getPermissionSystemStatus({ ...DEFAULT_EXTENSION_CONFIG, yoloMode: true }),
-    "yolo",
+    "YOLO mode enabled 🚀 ",
   );
+  assert.equal(
+    getPermissionSystemStatus({ ...DEFAULT_EXTENSION_CONFIG, yoloMode: true, yoloStatusMessage: null }),
+    undefined,
+  );
+});
+
+runTest("Extension config allows disabling YOLO status text with null", () => {
+  const normalized = normalizePermissionSystemConfig({
+    yoloStatusMessage: null,
+  });
+
+  assert.equal(normalized.yoloStatusMessage, null);
 });
 
 runTest("System prompt sanitizer removes the Available tools section and surrounding boilerplate", () => {

--- a/tests/permission-system.test.ts
+++ b/tests/permission-system.test.ts
@@ -78,6 +78,12 @@ type MockHandler = (
   ctx: Record<string, unknown>,
 ) => Promise<Record<string, unknown> | void> | Record<string, unknown> | void;
 
+type ShortcutRegistration = {
+  shortcut: string;
+  description: string | undefined;
+  handler: (ctx: Record<string, unknown>) => Promise<void> | void;
+};
+
 type ExtensionHarness = {
   baseDir: string;
   cwd: string;
@@ -141,12 +147,13 @@ function createToolCallHarness(
       on: (name: string, handler: MockHandler): void => {
         handlers[name] = handler;
       },
-      registerCommand: (): void => {},
+      registerCommand: (): void => { },
+      registerShortcut: (): void => { },
       getAllTools: (): Array<{ name: string }> => toolNames.map((name) => ({ name })),
-      setActiveTools: (): void => {},
-      registerProvider: (): void => {},
+      setActiveTools: (): void => { },
+      registerProvider: (): void => { },
       events: {
-        emit: (): void => {},
+        emit: (): void => { },
       },
     } as never);
   } finally {
@@ -190,8 +197,8 @@ function createMockContext(
       getSessionDir: (): string => cwd,
     },
     ui: {
-      notify: (): void => {},
-      setStatus: (): void => {},
+      notify: (): void => { },
+      setStatus: (): void => { },
       select: async (title: string): Promise<string | undefined> => {
         prompts.push(title);
         return options.selectResponse ?? "Yes";
@@ -258,6 +265,9 @@ runTest("Permission-system extension config loads yolo mode when explicitly enab
       permissionReviewLog: false,
       yoloMode: true,
       yoloStatusMessage: "YOLO mode enabled 🚀 ",
+      shortcutBindings: {
+        toggleYoloMode: "f8",
+      },
     });
   } finally {
     rmSync(baseDir, { recursive: true, force: true });
@@ -311,6 +321,9 @@ runTest("Permission-system extension config save persists normalized config", ()
       permissionReviewLog: false,
       yoloMode: true,
       yoloStatusMessage: "YOLO mode enabled 🚀 ",
+      shortcutBindings: {
+        toggleYoloMode: "f8",
+      },
     });
   } finally {
     rmSync(baseDir, { recursive: true, force: true });
@@ -378,6 +391,187 @@ runTest("Extension config allows disabling YOLO status text with null", () => {
   });
 
   assert.equal(normalized.yoloStatusMessage, null);
+});
+
+runTest("Extension config allows disabling YOLO shortcut with null", () => {
+  const normalized = normalizePermissionSystemConfig({
+    shortcutBindings: {
+      toggleYoloMode: null,
+    },
+  });
+
+  assert.equal(normalized.shortcutBindings.toggleYoloMode, null);
+});
+
+await runAsyncTest("Extension registers f8 shortcut for YOLO toggle", async () => {
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const originalExtensionConfig = existsSync(CONFIG_PATH) ? readFileSync(CONFIG_PATH, "utf8") : null;
+  const baseDir = mkdtempSync(join(tmpdir(), "pi-permission-system-shortcut-"));
+  const shortcuts: ShortcutRegistration[] = [];
+
+  mkdirSync(join(baseDir, "agents"), { recursive: true });
+  writeFileSync(join(baseDir, "pi-permissions.jsonc"), `${JSON.stringify({ defaultPolicy: { tools: "allow", bash: "allow", mcp: "allow", skills: "allow", special: "allow" } }, null, 2)}\n`, "utf8");
+  writeFileSync(CONFIG_PATH, `${JSON.stringify(DEFAULT_EXTENSION_CONFIG, null, 2)}\n`, "utf8");
+  process.env.PI_CODING_AGENT_DIR = baseDir;
+
+  try {
+    piPermissionSystemExtension({
+      on: (): void => { },
+      registerCommand: (): void => { },
+      registerShortcut: (shortcut: string, definition: { description?: string; handler: (ctx: Record<string, unknown>) => Promise<void> | void }): void => {
+        shortcuts.push({ shortcut, description: definition.description, handler: definition.handler });
+      },
+      getAllTools: (): Array<{ name: string }> => [],
+      setActiveTools: (): void => { },
+      registerProvider: (): void => { },
+      events: {
+        emit: (): void => { },
+      },
+    } as never);
+
+    assert.equal(shortcuts.some((entry) => entry.shortcut === "f8"), true);
+  } finally {
+    if (originalAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    }
+    if (originalExtensionConfig === null) {
+      if (existsSync(CONFIG_PATH)) {
+        unlinkSync(CONFIG_PATH);
+      }
+    } else {
+      writeFileSync(CONFIG_PATH, originalExtensionConfig, "utf8");
+    }
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+});
+
+await runAsyncTest("Extension does not register YOLO shortcut when disabled", async () => {
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const originalExtensionConfig = existsSync(CONFIG_PATH) ? readFileSync(CONFIG_PATH, "utf8") : null;
+  const baseDir = mkdtempSync(join(tmpdir(), "pi-permission-system-shortcut-disabled-"));
+  const shortcuts: ShortcutRegistration[] = [];
+
+  mkdirSync(join(baseDir, "agents"), { recursive: true });
+  writeFileSync(join(baseDir, "pi-permissions.jsonc"), `${JSON.stringify({ defaultPolicy: { tools: "allow", bash: "allow", mcp: "allow", skills: "allow", special: "allow" } }, null, 2)}\n`, "utf8");
+  writeFileSync(
+    CONFIG_PATH,
+    `${JSON.stringify({ ...DEFAULT_EXTENSION_CONFIG, shortcutBindings: { toggleYoloMode: null } }, null, 2)}\n`,
+    "utf8",
+  );
+  process.env.PI_CODING_AGENT_DIR = baseDir;
+
+  try {
+    piPermissionSystemExtension({
+      on: (): void => { },
+      registerCommand: (): void => { },
+      registerShortcut: (shortcut: string, definition: { description?: string; handler: (ctx: Record<string, unknown>) => Promise<void> | void }): void => {
+        shortcuts.push({ shortcut, description: definition.description, handler: definition.handler });
+      },
+      getAllTools: (): Array<{ name: string }> => [],
+      setActiveTools: (): void => { },
+      registerProvider: (): void => { },
+      events: {
+        emit: (): void => { },
+      },
+    } as never);
+
+    assert.equal(shortcuts.length, 0);
+  } finally {
+    if (originalAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    }
+    if (originalExtensionConfig === null) {
+      if (existsSync(CONFIG_PATH)) {
+        unlinkSync(CONFIG_PATH);
+      }
+    } else {
+      writeFileSync(CONFIG_PATH, originalExtensionConfig, "utf8");
+    }
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+});
+
+await runAsyncTest("YOLO shortcut toggles mode and persists config", async () => {
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const originalExtensionConfig = existsSync(CONFIG_PATH) ? readFileSync(CONFIG_PATH, "utf8") : null;
+  const baseDir = mkdtempSync(join(tmpdir(), "pi-permission-system-shortcut-toggle-"));
+  const shortcuts: ShortcutRegistration[] = [];
+  const statusUpdates: Array<{ key: string; value: string | undefined }> = [];
+
+  mkdirSync(join(baseDir, "agents"), { recursive: true });
+  writeFileSync(join(baseDir, "pi-permissions.jsonc"), `${JSON.stringify({ defaultPolicy: { tools: "allow", bash: "allow", mcp: "allow", skills: "allow", special: "allow" } }, null, 2)}\n`, "utf8");
+  writeFileSync(CONFIG_PATH, `${JSON.stringify(DEFAULT_EXTENSION_CONFIG, null, 2)}\n`, "utf8");
+  process.env.PI_CODING_AGENT_DIR = baseDir;
+
+  try {
+    piPermissionSystemExtension({
+      on: (): void => { },
+      registerCommand: (): void => { },
+      registerShortcut: (shortcut: string, definition: { description?: string; handler: (ctx: Record<string, unknown>) => Promise<void> | void }): void => {
+        shortcuts.push({ shortcut, description: definition.description, handler: definition.handler });
+      },
+      getAllTools: (): Array<{ name: string }> => [],
+      setActiveTools: (): void => { },
+      registerProvider: (): void => { },
+      events: {
+        emit: (): void => { },
+      },
+    } as never);
+
+    const shortcut = shortcuts.find((entry) => entry.shortcut === "f8");
+    assert.ok(shortcut);
+
+    await Promise.resolve(
+      shortcut.handler({
+        hasUI: true,
+        cwd: baseDir,
+        sessionManager: {
+          getEntries: (): unknown[] => [],
+          getSessionId: (): string => "test-session",
+          getSessionDir: (): string => baseDir,
+        },
+        ui: {
+          notify: (): void => { },
+          select: async (): Promise<string | undefined> => undefined,
+          confirm: async (): Promise<boolean> => false,
+          input: async (): Promise<string | undefined> => undefined,
+          custom: async (): Promise<unknown> => undefined,
+          setStatus: (key: string, value: string | undefined): void => {
+            statusUpdates.push({ key, value });
+          },
+        },
+      }),
+    );
+
+    const loaded = loadPermissionSystemConfig();
+    assert.equal(loaded.config.yoloMode, true);
+    assert.equal(
+      statusUpdates.some(
+        (entry) =>
+          entry.key === "pi-permission-system" &&
+          entry.value === DEFAULT_EXTENSION_CONFIG.yoloStatusMessage,
+      ),
+      true,
+    );
+  } finally {
+    if (originalAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    }
+    if (originalExtensionConfig === null) {
+      if (existsSync(CONFIG_PATH)) {
+        unlinkSync(CONFIG_PATH);
+      }
+    } else {
+      writeFileSync(CONFIG_PATH, originalExtensionConfig, "utf8");
+    }
+    rmSync(baseDir, { recursive: true, force: true });
+  }
 });
 
 runTest("System prompt sanitizer removes the Available tools section and surrounding boilerplate", () => {

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+
+import { registerConfiguredShortcuts, type ShortcutActionDefinition } from "../src/shortcuts.js";
+import type { PermissionSystemExtensionConfig } from "../src/extension-config.js";
+import { runTest } from "./test-harness.js";
+
+type ShortcutRegistration = {
+  shortcut: string;
+  description?: string;
+};
+
+runTest("registerConfiguredShortcuts registers configured actions and skips null bindings", () => {
+  const calls: ShortcutRegistration[] = [];
+  const warnings: string[] = [];
+
+  const config: PermissionSystemExtensionConfig = {
+    debugLog: false,
+    permissionReviewLog: true,
+    yoloMode: false,
+    shortcutBindings: {
+      toggleYoloMode: "f8",
+    },
+  };
+
+  const actions: ShortcutActionDefinition[] = [
+    {
+      id: "toggleYoloMode",
+      description: "Toggle YOLO",
+      getShortcut: (value) => value.shortcutBindings.toggleYoloMode,
+      handler: () => {},
+    },
+    {
+      id: "disabled",
+      description: "Disabled action",
+      getShortcut: () => null,
+      handler: () => {},
+    },
+  ];
+
+  registerConfiguredShortcuts(
+    {
+      registerShortcut: (shortcut: string, options: { description?: string }) => {
+        calls.push({ shortcut, description: options.description });
+      },
+    } as never,
+    config,
+    actions,
+    (warning) => {
+      warnings.push(warning);
+    },
+  );
+
+  assert.deepEqual(calls, [{ shortcut: "f8", description: "Toggle YOLO" }]);
+  assert.deepEqual(warnings, []);
+});
+
+runTest("registerConfiguredShortcuts reports registration failures", () => {
+  const warnings: string[] = [];
+
+  const config: PermissionSystemExtensionConfig = {
+    debugLog: false,
+    permissionReviewLog: true,
+    yoloMode: false,
+    shortcutBindings: {
+      toggleYoloMode: "f8",
+    },
+  };
+
+  registerConfiguredShortcuts(
+    {
+      registerShortcut: () => {
+        throw new Error("already bound");
+      },
+    } as never,
+    config,
+    [
+      {
+        id: "toggleYoloMode",
+        description: "Toggle YOLO",
+        getShortcut: (value) => value.shortcutBindings.toggleYoloMode,
+        handler: () => {},
+      },
+    ],
+    (warning) => {
+      warnings.push(warning);
+    },
+  );
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /Failed to register shortcut 'f8'/);
+});
+
+console.log("All permission-system shortcuts tests passed.");


### PR DESCRIPTION
This is two features, put together as a single merge request to prevent you from having to deal with merge conflicts if you're OK with adding both of them (I can split it up if you only want one and not the other).

## Feature 1 - Add configurable shortcut for YOLO mode

This is a nice way to switch YOLO mode on and off. Sometimes you want to keep a firm hand on the wheel, and sometimes you just want to let the agent do its thing. Now, you can do that with the press of a button. Defaults to `F8` (there weren't a lot of free keys available), but is configurable (info add to the README).

By a happy coincidence, this also fixes #16, which is a nice bonus.

## Feature 2 - Make the "yolo" UI status message configurable

To be honest, my agent didn't tell me the default "yolo" message was already there, so I added this text as the default: `YOLO mode enabled 🚀 `

I'm keeping this in this pull request because it solves another issue: The default text does not contain a newline, and so clashes when some of my other extensions have a UI status message. For example:

`yolo active subagents: 1/3`

The default text (which is configurable, for the classic `yolo` message fans) uses the rocket emoji, which works as a separator and makes it easier to distinguish between different UI status messages:

`YOLO mode enabled 🚀 active subagents: 1/3`

You can also disable the status message text entirely by setting `"yoloStatusMessage": null` in the `config.json` file. Great for keeping a minimalist UI status line.

---

Again, I can split this up if you want one and not the other, but I think both are great additions to this extension, and am hoping you'll include them both. :)

Thanks for making this extension btw! It's a real lifesaver.