### PR TITLE
fix(permission-system): split bash commands before permission check

### DIFF
--- a/src/bash-filter.ts
+++ b/src/bash-filter.ts
@@ -19,6 +19,17 @@ export interface BashPermissionCheck {
   command: string;
 }
 
+const SHELL_CONTROL_OPERATORS = /\s*(?:&&|\|\||;|\|&?)\s*/;
+
+export function splitShellCommand(command: string): string[] {
+  return command
+    .split(SHELL_CONTROL_OPERATORS)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+const STATE_RANK: Record<PermissionState, number> = { deny: 2, ask: 1, allow: 0 };
+
 export class BashFilter {
   private readonly compiledPatterns: CompiledPattern[];
 
@@ -32,17 +43,28 @@ export class BashFilter {
   }
 
   check(command: string): BashPermissionCheck {
-    const match = findCompiledWildcardMatch(this.compiledPatterns, command);
-    if (match) {
-      return {
-        state: match.state,
-        matchedPattern: match.matchedPattern,
-        command,
-      };
+    const segments = splitShellCommand(command);
+    if (segments.length === 0) {
+      return { state: this.defaultState, command };
+    }
+
+    let mostRestrictiveState: PermissionState | null = null;
+    let mostRestrictivePattern: string | undefined;
+
+    for (const segment of segments) {
+      const match = findCompiledWildcardMatch(this.compiledPatterns, segment);
+      const segmentState = match?.state ?? this.defaultState;
+
+      if (mostRestrictiveState === null || STATE_RANK[segmentState] > STATE_RANK[mostRestrictiveState]) {
+        mostRestrictiveState = segmentState;
+        mostRestrictivePattern = match?.matchedPattern;
+        if (mostRestrictiveState === "deny") break;
+      }
     }
 
     return {
-      state: this.defaultState,
+      state: mostRestrictiveState ?? this.defaultState,
+      matchedPattern: mostRestrictivePattern,
       command,
     };
   }

--- a/src/permission-manager.ts
+++ b/src/permission-manager.ts
@@ -24,6 +24,7 @@ import {
   findCompiledWildcardMatch,
   type CompiledWildcardPattern,
 } from "./wildcard-matcher.js";
+import { splitShellCommand } from "./bash-filter.js";
 
 const PERMISSION_POLICY_AGENT_DIR_ENV_KEY = "PI_PERMISSION_SYSTEM_POLICY_AGENT_DIR";
 
@@ -953,16 +954,32 @@ export class PermissionManager {
     if (normalizedToolName === "bash") {
       const record = toRecord(input);
       const command = typeof record.command === "string" ? record.command : "";
-      const result = findCompiledPermissionMatch(compiledBash, command);
+
+      const segments = splitShellCommand(command);
+      const stateRank: Record<PermissionState, number> = { deny: 2, ask: 1, allow: 0 };
+
+      let effectiveState: PermissionState | null = null;
+      let effectivePattern: string | undefined;
+
+      for (const segment of segments) {
+        const segmentResult = findCompiledPermissionMatch(compiledBash, segment);
+        const segmentState = segmentResult?.state
+          ?? toolMatch?.state
+          ?? resolveLayeredDefaultPermission(layers, "bash")?.state
+          ?? DEFAULT_POLICY.bash;
+
+        if (effectiveState === null || stateRank[segmentState] > stateRank[effectiveState]) {
+          effectiveState = segmentState;
+          effectivePattern = segmentResult?.matchedPattern;
+          if (effectiveState === "deny") break;
+        }
+      }
 
       return {
         toolName,
-        state: result?.state
-          ?? toolMatch?.state
-          ?? resolveLayeredDefaultPermission(layers, "bash")?.state
-          ?? DEFAULT_POLICY.bash,
+        state: effectiveState ?? DEFAULT_POLICY.bash,
         command,
-        matchedPattern: result?.matchedPattern,
+        matchedPattern: effectivePattern,
         source: "bash",
       };
     }


### PR DESCRIPTION
## Problem

Wildcard bash patterns like `cd *` compile to `^cd( .*)?$` with the
dotAll (`s`) flag. This causes `.*` to greedily consume shell operators,
so a command like `cd /tmp && git commit` fully matches `cd *` — and
`git commit` is never checked against its own rule.

Example: with `"cd *": "allow"` and `"git *": "ask"`, running
`cd /tmp && git commit` is silently allowed without prompting.

## Fix

Split the command on shell operators (`&&`, `||`, `;`, `|`, `|&`)
before matching. Each segment is checked independently. The most
restrictive result (`deny` > `ask` > `allow`) wins.