### PR TITLE
fix: accept OMP systemPrompt string[] without crashing

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -164,6 +164,24 @@ export function normalizeLineEndings(prompt: string): string {
   return prompt.replace(/\r\n/g, "\n");
 }
 
+/**
+ * Some hosts (e.g. OMP) pass `systemPrompt` as `string[]`; classic Pi used `string`.
+ * Normalize both shapes (and unexpected values) to a single string.
+ */
+export function normalizeSystemPromptText(systemPrompt: unknown): string {
+  if (typeof systemPrompt === "string") {
+    return systemPrompt;
+  }
+
+  if (Array.isArray(systemPrompt)) {
+    return systemPrompt
+      .filter((part): part is string => typeof part === "string")
+      .join("\n\n");
+  }
+
+  return "";
+}
+
 export function extractFrontmatter(markdown: string): string {
   const normalized = markdown.replace(/\r\n/g, "\n");
   if (!normalized.startsWith("---\n")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   normalizeAgentName,
   normalizePathForComparison,
   normalizePathResourceForPermission,
+  normalizeSystemPromptText,
   PERMISSION_SYSTEM_COMMAND_DESCRIPTION,
   toRecord,
 } from "./common.js";
@@ -294,12 +295,13 @@ function getActiveAgentName(ctx: ExtensionContext): string | null {
   return null;
 }
 
-function getActiveAgentNameFromSystemPrompt(systemPrompt: string | undefined): string | null {
-  if (!systemPrompt) {
+function getActiveAgentNameFromSystemPrompt(systemPrompt: unknown): string | null {
+  const normalized = normalizeSystemPromptText(systemPrompt);
+  if (!normalized) {
     return null;
   }
 
-  const match = systemPrompt.match(ACTIVE_AGENT_TAG_REGEX);
+  const match = normalized.match(ACTIVE_AGENT_TAG_REGEX);
   if (!match || !match[1]) {
     return null;
   }
@@ -315,7 +317,8 @@ function getContextSystemPrompt(ctx: ExtensionContext): string | undefined {
 
   try {
     const systemPrompt: unknown = getSystemPrompt.call(ctx);
-    return typeof systemPrompt === "string" ? systemPrompt : undefined;
+    const normalized = normalizeSystemPromptText(systemPrompt);
+    return normalized || undefined;
   } catch (error) {
     logPermissionForwardingWarning("Failed to read context system prompt for forwarded permission metadata", error);
     return undefined;
@@ -1772,7 +1775,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     queueForwardedPermissionRequestScan();
   };
 
-  const resolveAgentName = (ctx: ExtensionContext, systemPrompt?: string): string | null => {
+  const resolveAgentName = (ctx: ExtensionContext, systemPrompt?: unknown): string | null => {
     const fromSession = getActiveAgentName(ctx);
     if (fromSession) {
       lastKnownActiveAgentName = fromSession;
@@ -1876,7 +1879,9 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
     runtimeContext = ctx;
     refreshExtensionConfig(ctx);
     startForwardedPermissionPolling(ctx);
-    const agentName = resolveAgentName(ctx, event.systemPrompt);
+    // Some hosts provide string[]; classic Pi provided string. Normalize once.
+    const systemPromptText = normalizeSystemPromptText(event.systemPrompt);
+    const agentName = resolveAgentName(ctx, systemPromptText);
     const allTools = pi.getAllTools();
     const allowedTools: string[] = [];
 
@@ -1901,7 +1906,7 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
       agentName,
       cwd: ctx.cwd,
       permissionStamp: permissionManager.getPolicyCacheStamp(agentName ?? undefined),
-      systemPrompt: event.systemPrompt,
+      systemPrompt: systemPromptText,
       allowedToolNames: allowedTools,
     });
 
@@ -1912,18 +1917,19 @@ export default function piPermissionSystemExtension(pi: ExtensionAPI): void {
         : { systemPrompt: lastPromptStateCacheResult.systemPrompt };
     }
 
-    const toolPromptResult = sanitizeAvailableToolsSection(event.systemPrompt, allowedTools);
+    const toolPromptResult = sanitizeAvailableToolsSection(systemPromptText, allowedTools);
     const skillPromptResult = resolveSkillPromptEntries(toolPromptResult.prompt, permissionManager, agentName, ctx.cwd);
     activeSkillEntries = skillPromptResult.entries;
 
     const cachedResult: CachedPromptStateResult = {
       entries: skillPromptResult.entries,
-      systemPrompt: skillPromptResult.prompt !== event.systemPrompt ? skillPromptResult.prompt : undefined,
+      systemPrompt: skillPromptResult.prompt !== systemPromptText ? skillPromptResult.prompt : undefined,
     };
     lastPromptStateCacheKey = promptStateCacheKey;
     lastPromptStateCacheResult = cachedResult;
 
     if (cachedResult.systemPrompt !== undefined) {
+      // Hosts that accept string | string[] can wrap a returned string as [string].
       return { systemPrompt: cachedResult.systemPrompt };
     }
 

--- a/src/types-shims.d.ts
+++ b/src/types-shims.d.ts
@@ -148,7 +148,8 @@ declare module "@earendil-works/pi-coding-agent" {
   }
 
   export interface BeforeAgentStartEvent {
-    systemPrompt: string;
+    // Some hosts (e.g. OMP) pass string[]; classic Pi passes string.
+    systemPrompt: string | string[];
   }
 
   export interface InputEvent {
@@ -187,7 +188,8 @@ declare module "@earendil-works/pi-coding-agent" {
   }
 
   export interface BeforeAgentStartEventResult {
-    systemPrompt?: string;
+    // Hosts may accept string | string[]; runners can coerce string -> [string].
+    systemPrompt?: string | string[];
   }
 
   export interface InputEventResult {

--- a/tests/permission-system.test.ts
+++ b/tests/permission-system.test.ts
@@ -827,15 +827,19 @@ await runAsyncTest("before_agent_start accepts OMP-style systemPrompt string arr
 
   try {
     const ctx = createMockContext(harness.cwd, harness.prompts);
+    // Pass the array payload directly; harness typing still expects classic Pi's string.
     const result = await Promise.resolve(
       harness.handlers.before_agent_start?.(
-        { systemPrompt: promptParts as unknown as string },
+        { systemPrompt: promptParts as any },
         ctx,
       ),
     ) as Record<string, unknown> | undefined;
 
     // Must not throw on .match / sanitize when systemPrompt is string[].
-    const systemPrompt = String(result?.systemPrompt ?? "");
+    // Assert the return shape explicitly: returning string[] would still stringify,
+    // so String(...) alone would hide that regression.
+    assert.equal(typeof result?.systemPrompt, "string", "Handler should return a sanitized systemPrompt string");
+    const systemPrompt = result.systemPrompt as string;
     assert.equal(systemPrompt.includes("allowed-skill"), true, "Allowed skill should remain visible for string[] prompts");
     assert.equal(systemPrompt.includes("blocked-skill"), false, "Blocked skill should stay hidden for string[] prompts");
     assert.equal(systemPrompt.includes("Available tools:"), false, "Available tools section should still be sanitized");

--- a/tests/permission-system.test.ts
+++ b/tests/permission-system.test.ts
@@ -788,6 +788,72 @@ await runAsyncTest("before_agent_start returns cached sanitized prompts on repea
   }
 });
 
+await runAsyncTest("before_agent_start accepts OMP-style systemPrompt string arrays without crashing", async () => {
+  const harness = createToolCallHarness(
+    {
+      defaultPolicy: { tools: "allow", bash: "ask", mcp: "ask", skills: "deny", special: "allow" },
+      skills: { "allowed-skill": "allow", "blocked-skill": "deny" },
+    },
+    ["read"],
+  );
+  const allowedSkillPath = join(harness.cwd, "skills", "allowed", "SKILL.md");
+  const blockedSkillPath = join(harness.cwd, "skills", "blocked", "SKILL.md");
+  // OMP-style payload: systemPrompt arrives as string[] rather than a single string.
+  const promptParts = [
+    '<active_agent name="orchestrator" mode="direct">',
+    [
+      "<available_skills>",
+      "  <skill>",
+      "    <name>allowed-skill</name>",
+      "    <description>Allowed skill</description>",
+      `    <location>${allowedSkillPath}</location>`,
+      "  </skill>",
+      "  <skill>",
+      "    <name>blocked-skill</name>",
+      "    <description>Blocked skill</description>",
+      `    <location>${blockedSkillPath}</location>`,
+      "  </skill>",
+      "</available_skills>",
+    ].join("\n"),
+    [
+      "Available tools:",
+      "- read",
+      "- write",
+      "",
+      "Guidelines:",
+      "- Be concise in your responses",
+    ].join("\n"),
+  ];
+
+  try {
+    const ctx = createMockContext(harness.cwd, harness.prompts);
+    const result = await Promise.resolve(
+      harness.handlers.before_agent_start?.(
+        { systemPrompt: promptParts as unknown as string },
+        ctx,
+      ),
+    ) as Record<string, unknown> | undefined;
+
+    // Must not throw on .match / sanitize when systemPrompt is string[].
+    const systemPrompt = String(result?.systemPrompt ?? "");
+    assert.equal(systemPrompt.includes("allowed-skill"), true, "Allowed skill should remain visible for string[] prompts");
+    assert.equal(systemPrompt.includes("blocked-skill"), false, "Blocked skill should stay hidden for string[] prompts");
+    assert.equal(systemPrompt.includes("Available tools:"), false, "Available tools section should still be sanitized");
+    assert.equal(systemPrompt.includes("Be concise in your responses"), true, "Non-tool guidance should remain");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+await runAsyncTest("normalizeSystemPromptText accepts string and string[] shapes", async () => {
+  const { normalizeSystemPromptText } = await import("../src/common.js");
+  assert.equal(normalizeSystemPromptText("hello"), "hello");
+  assert.equal(normalizeSystemPromptText(["a", "b"]), "a\n\nb");
+  assert.equal(normalizeSystemPromptText(["a", 1, "b"] as unknown as string[]), "a\n\nb");
+  assert.equal(normalizeSystemPromptText(undefined), "");
+  assert.equal(normalizeSystemPromptText(null), "");
+});
+
 await runAsyncTest("Permission-system logger writes review entries without debug and debug entries only when debug is enabled", async () => {
   const baseDir = mkdtempSync(join(tmpdir(), "pi-permission-system-logs-"));
   const logsDir = join(baseDir, "logs");


### PR DESCRIPTION
## Problem

On Oh My Pi (OMP), `pi-permission-system@0.8.0` crashes during `before_agent_start` with:

```text
systemPrompt.match is not a function
(In 'systemPrompt.match(ACTIVE_AGENT_TAG_REGEX)', 'systemPrompt.match' is undefined)
```

Classic Pi passes `BeforeAgentStartEvent.systemPrompt` as a `string`, but OMP passes `string[]`. The extension assumed a string and called `.match()` directly.

Related issue: #33

## Fix

- Add `normalizeSystemPromptText()` to accept `string | string[]` (and ignore unexpected values)
- Normalize before:
  - active-agent extraction (`.match(ACTIVE_AGENT_TAG_REGEX)`)
  - `before_agent_start` sanitization / cache-key generation
  - `ctx.getSystemPrompt()` reads used for forwarded permission metadata
- Widen type shims to `string | string[]`
- Returning a sanitized `systemPrompt` as `string` remains compatible; OMP wraps it as `[string]`

## Tests

- `before_agent_start` accepts OMP-style `systemPrompt: string[]` without crashing and still sanitizes skills / available tools
- `normalizeSystemPromptText` unit coverage for string / string[] / invalid values

```bash
bun ./tests/permission-system.test.ts
```

## Notes

Verified against a local OMP install of `0.8.0` where the same crash reproduced before this normalization.